### PR TITLE
fix: bump rand version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altcha-lib-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["jmic <jmic@users.noreply.github.com>"]
 description = "Community implementation of the Altcha library in Rust for your own server application to create and validate challenges and responses."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["json"]
 
 [dependencies]
 chrono = "0.4"
-rand = "0"
+rand = "0.9.0"
 sha2 = "0"
 base16ct = { version = "0.2", features = ["alloc"] }
 sha1 = "0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,13 @@ pub enum Error {
     SolveChallengeMaxNumberReached(String),
     WrongChallengeInput(String),
     General(String),
+    RandError(rand::distr::uniform::Error),
+}
+
+impl From<rand::distr::uniform::Error> for Error {
+    fn from(value: rand::distr::uniform::Error) -> Self {
+        Error::RandError(value)
+    }
 }
 
 #[cfg(feature = "json")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,9 +103,10 @@ pub fn create_challenge(options: ChallengeOptions) -> Result<Challenge, Error> {
             max_number
         )));
     }
-    let number = options
-        .number
-        .unwrap_or_else(|| utils::random_int(max_number));
+    let number = match options.number {
+        Some(n) => n,
+        None => utils::random_int(max_number)?,
+    };
 
     let (mut salt, mut salt_params) = utils::extract_salt_params(salt.as_str());
 
@@ -301,6 +302,8 @@ pub fn solve_challenge(
     )))
 }
 
+const EXPIRES_PRAM: &str = "expires";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,5 +374,3 @@ mod tests {
         assert!(challenge.is_err());
     }
 }
-
-const EXPIRES_PRAM: &str = "expires";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::algorithm::AltchaAlgorithm;
 use hmac::digest::{Digest, KeyInit};
 use hmac::{Hmac, Mac};
+use rand::distr::uniform::Error;
 use rand::Rng;
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
@@ -13,15 +14,15 @@ pub type ParamsMapType = HashMap<String, String>;
 
 pub fn random_bytes(len: usize) -> Vec<u8> {
     let mut values: Vec<u8> = vec![0; len];
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     rng.fill(values.as_mut_slice());
     values
 }
 
-pub fn random_int(max: u64) -> u64 {
-    let mut rng = rand::thread_rng();
-    let dist = rand::distributions::Uniform::new_inclusive(0, max);
-    rng.sample(dist)
+pub fn random_int(max: u64) -> Result<u64, Error> {
+    let mut rng = rand::rng();
+    let dist = rand::distr::Uniform::new_inclusive(0, max)?;
+    Ok(rng.sample(dist))
 }
 
 pub fn hash_function(altcha_algorithm: &AltchaAlgorithm, data: &str) -> String {


### PR DESCRIPTION
Rand was updated and shortened `rand::distribution` to `rand::distr` and broke the package.

Locking rand version and renaming some imports fixes this.