### PR TITLE
feat: add support for thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altcha-lib-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["jmic <jmic@users.noreply.github.com>"]
 description = "Community implementation of the Altcha library in Rust for your own server application to create and validate challenges and responses."
@@ -25,6 +25,7 @@ sha1 = "0"
 hmac = "0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+thiserror = "2.0.12"
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,25 @@
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[cfg(feature = "json")]
+    #[error("JSON parsing error: {0}")]
     ParseJson(serde_json::Error),
+    #[error("Integer parsing error: {0}")]
     ParseInteger(std::num::ParseIntError),
+    #[error("Expiration parsing error: {0}")]
     ParseExpire(String),
+    #[error("Solution expired: {0}")]
     VerificationFailedExpired(String),
+    #[error("Solution does not match the challenge: {0}")]
     VerificationMismatchChallenge(String),
+    #[error("Signature in the solution does not match the challenge: {0}")]
     VerificationMismatchSignature(String),
+    #[error("Max number reached: {0}")]
     SolveChallengeMaxNumberReached(String),
+    #[error("Wrong challenge input: {0}")]
     WrongChallengeInput(String),
+    #[error("Altcha error: {0}")]
     General(String),
+    #[error("Error in the randomizer: {0}")]
     RandError(rand::distr::uniform::Error),
 }
 


### PR DESCRIPTION
This is a small change, but I wanted to use this library with the thiserror crate for better error handling. I've noticed that it was returning errors due to this library.

If you don't want to use another external library I could also implement it manually using std::fmt::Display and std::error::Error, but I think it would be more boilerplate

Generally I think this could improve overall error handling, since thiserror implements std::error::Error which helps in general with compatibility with crates that expect error enums to implement this trait.

I'm not sure if those error messages fit, so feel free to review them and fix.

Cheers.